### PR TITLE
Redirect to user's profile when user_return_to is not set.

### DIFF
--- a/lib/flix_web/controllers/user_auth.ex
+++ b/lib/flix_web/controllers/user_auth.ex
@@ -33,7 +33,7 @@ defmodule FlixWeb.UserAuth do
     |> put_session(:user_token, token)
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
     |> maybe_write_remember_me_cookie(token, params)
-    |> redirect(to: user_return_to || signed_in_path(conn))
+    |> redirect(to: user_return_to || "/fans/#{user.id}")
   end
 
   defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do


### PR DESCRIPTION
This PR supports the following features:

Closes #10 