### PR TITLE
Bump Elixir and Erlang to the latest stable releases.

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 # Elixir version
-elixir_version=1.11.4
+elixir_version=1.12.0
 
 # Erlang version
-erlang_version=23.3.1
+erlang_version=24.0.1

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Flix.MixProject do
     [
       app: :flix,
       version: "0.1.0",
-      elixir: "~> 1.11.4",
+      elixir: "~> 1.12.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,2 +1,2 @@
 # Node.js version
-node_version=14.16.0
+node_version=14.17.0


### PR DESCRIPTION
This PR supports the following features:

- Bump to Erlang 24.0.1
- Bump to Elixir 1.12.0
- Update Heroku buildpacks