### PR TITLE
Rollback to Node 16.14.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The purpose of this project is to implement an application where fans can commen
 
 - Erlang 24.2.2 or newer
 
-- Node 17.6.0 or newer
+- Node 16.14.0 or newer
 
 - Phoenix 1.6.6 or newer
 

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -39,12 +39,12 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.6.2",
+      "version": "1.6.6",
       "integrity": "sha512-VjR27NETvrLSj8rI6DlpVAfo7pCYth/9+1OCoTof4LKEbq0141ze/tdxFHHZzVQSok3gqJUo2h/tqbxR3r8eyw==",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "integrity": "sha512-PB41xiF7pDzUSL+iKHI4xvGPLY9tUD2C/BE7oEWcCpt3+wrNweAlhbLk2tzM7uQOTZHMyaTLs1rYytg0t5aJyw=="
     },
     "node_modules/@babel/code-frame": {

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,2 +1,2 @@
 # Node.js version
-node_version=17.6.0
+node_version=16.14.0


### PR DESCRIPTION
This PR supports the following features:

- rollback to Node 16.14.0

- add support GraphQL authentication