### PR TITLE
Update-to-elixir-1.16.0-otp-26

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-26
+elixir 1.16.0-otp-26
 erlang 26.1.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of this project is to implement an application where fans can commen
 
 ## Software requirements
 
-- Elixir 1.15.7 or newer
+- Elixir 1.16.0 or newer
 
 - Erlang 26.1.2 or newer
 
@@ -14,7 +14,7 @@ The purpose of this project is to implement an application where fans can commen
 
 - PostgreSQL 15.4 or newer
 
-Note: This tutorial was updated on macOS 14.0.0.
+Note: This tutorial was updated on macOS 14.2.1.
 
 ## Communication
 
@@ -86,4 +86,4 @@ Flix is released under the [MIT license](./LICENSE.md).
 
 ## Copyright
 
-copyright:: (c) Copyright 2021 - 2023 Conrad Taylor. All Rights Reserved.
+copyright:: (c) Copyright 2021 - 2024 Conrad Taylor. All Rights Reserved.

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Flix.MixProject do
     [
       app: :flix,
       version: "0.1.0",
-      elixir: "~> 1.15.7",
+      elixir: "~> 1.16.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
This PR supports the following features:

- update to Elixir 1.16.0